### PR TITLE
Add space weather and solar flare datasets

### DIFF
--- a/.github/workflows/update-solar-flares.yml
+++ b/.github/workflows/update-solar-flares.yml
@@ -1,0 +1,30 @@
+name: Update Solar Flares
+on:
+  schedule:
+    - cron: '0 12 * * *'  # daily at 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment: HF
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pandas pyarrow numpy requests netCDF4 huggingface_hub[hf_xet]
+      - run: python scripts/update-solar-flares.py
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      - name: Update status
+        run: python scripts/update-status.py solar-flares
+      - name: Push status
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add status.json
+          git diff --cached --quiet || git commit -m "status: solar-flares updated $(date -u +%Y-%m-%d)" && git push

--- a/.github/workflows/update-space-weather.yml
+++ b/.github/workflows/update-space-weather.yml
@@ -1,0 +1,30 @@
+name: Update Space Weather
+on:
+  schedule:
+    - cron: '0 11 * * *'  # daily at 11:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment: HF
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pandas pyarrow huggingface_hub[hf_xet]
+      - run: python scripts/update-space-weather.py
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      - name: Update status
+        run: python scripts/update-status.py space-weather
+      - name: Push status
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add status.json
+          git diff --cached --quiet || git commit -m "status: space-weather updated $(date -u +%Y-%m-%d)" && git push

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Automated pipelines that keep space-related datasets on Hugging Face up to date.
 ![Update Starlink Fleet](https://github.com/juliensimon/space-datasets/actions/workflows/update-starlink.yml/badge.svg)
 ![Update Ground Stations](https://github.com/juliensimon/space-datasets/actions/workflows/update-ground-stations.yml/badge.svg)
 ![Update NEO Close Approaches](https://github.com/juliensimon/space-datasets/actions/workflows/update-neo.yml/badge.svg)
+![Update Space Weather](https://github.com/juliensimon/space-datasets/actions/workflows/update-space-weather.yml/badge.svg)
+![Update Solar Flares](https://github.com/juliensimon/space-datasets/actions/workflows/update-solar-flares.yml/badge.svg)
 
 ## Datasets
 
@@ -18,6 +20,8 @@ Automated pipelines that keep space-related datasets on Hugging Face up to date.
 | [starlink-fleet-data](https://huggingface.co/datasets/juliensimon/starlink-fleet-data) | ![Starlink](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$.starlink&label=updated&color=brightgreen) | Daily 08:00 UTC | CelesTrak | Daily constellation snapshots |
 | [starlink-ground-stations](https://huggingface.co/datasets/juliensimon/starlink-ground-stations) | ![Ground Stations](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['ground-stations']&label=updated&color=brightgreen) | Daily 09:00 UTC | Starlink Insider + FCC IBFS | Gateways + PoPs |
 | [neo-close-approaches](https://huggingface.co/datasets/juliensimon/neo-close-approaches) | ![NEO](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$.neo&label=updated&color=brightgreen) | Daily 10:00 UTC | NASA JPL CNEOS | ~35K close approaches |
+| [space-weather-indices](https://huggingface.co/datasets/juliensimon/space-weather-indices) | ![Space Weather](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['space-weather']&label=updated&color=brightgreen) | Daily 11:00 UTC | CelesTrak / NOAA SWPC | Daily indices since 1957 |
+| [solar-flare-events](https://huggingface.co/datasets/juliensimon/solar-flare-events) | ![Solar Flares](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['solar-flares']&label=updated&color=brightgreen) | Daily 12:00 UTC | NCEI GOES-16 + SWPC | ~16K flare events (2017+) |
 
 ## How it works
 
@@ -48,6 +52,13 @@ python scripts/update-ground-stations.py
 
 # Update NEO close approaches
 python scripts/update-neo.py
+
+# Update space weather indices
+python scripts/update-space-weather.py
+
+# Update solar flare events (requires netCDF4)
+pip install netCDF4
+python scripts/update-solar-flares.py
 ```
 
 ## Bulk ingestion

--- a/scripts/update-solar-flares.py
+++ b/scripts/update-solar-flares.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Fetch solar flare events from GOES-16 (NCEI) + SWPC daily report and upload to HF."""
+
+import re
+import subprocess
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import requests
+
+try:
+    import netCDF4 as nc
+except ImportError:
+    nc = None
+
+
+NCEI_BASE = "https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/goes16/l2/data/xrsf-l2-flsum_science/"
+SWPC_EVENTS = "https://services.swpc.noaa.gov/text/solar-geophysical-event-reports.txt"
+HF_REPO = "juliensimon/solar-flare-events"
+
+EPOCH = datetime(2000, 1, 1, 12, 0, 0)
+
+
+def fetch_ncei_flares():
+    """Download and parse the GOES-16 mission-length NetCDF flare summary."""
+    if nc is None:
+        raise RuntimeError("netCDF4 is required: pip install netCDF4")
+
+    # Discover the current filename
+    print("  Discovering NCEI flare summary file...")
+    resp = requests.get(NCEI_BASE, timeout=30)
+    resp.raise_for_status()
+    match = re.search(r'href="(sci_xrsf-l2-flsum_g16_[^"]+\.nc)"', resp.text)
+    if not match:
+        raise RuntimeError(f"Could not find NetCDF file at {NCEI_BASE}")
+    filename = match.group(1)
+    url = NCEI_BASE + filename
+    print(f"  Downloading {filename}...")
+
+    # Download to temp file
+    resp = requests.get(url, timeout=120)
+    resp.raise_for_status()
+    tmp_nc = Path(tempfile.mktemp(suffix=".nc"))
+    tmp_nc.write_bytes(resp.content)
+    print(f"  {len(resp.content) / 1024 / 1024:.1f} MB downloaded")
+
+    # Parse NetCDF
+    ds = nc.Dataset(str(tmp_nc))
+    times = ds.variables["time"][:]
+    statuses = ds.variables["status"][:]
+    flare_ids = ds.variables["flare_id"][:]
+    classes = ds.variables["flare_class"][:]
+    fluxes = ds.variables["xrsb_flux"][:]
+    ds.close()
+    tmp_nc.unlink()
+
+    # Pivot: one row per flare, extracting start/peak/end times and peak flux
+    records = {}
+    for i in range(len(flare_ids)):
+        fid = int(flare_ids[i])
+        t = EPOCH + timedelta(seconds=float(times[i]))
+        status = statuses[i]
+        flux = float(fluxes[i]) if not np.ma.is_masked(fluxes[i]) else None
+
+        if fid not in records:
+            records[fid] = {"flare_id": fid, "satellite": "GOES-16"}
+
+        rec = records[fid]
+        if status == "EVENT_START":
+            rec["start_time"] = t
+        elif status == "EVENT_PEAK":
+            rec["peak_time"] = t
+            rec["peak_flux_wm2"] = flux
+            cls = classes[i].strip()
+            if cls:
+                rec["goes_class"] = cls
+        elif status == "EVENT_END":
+            rec["end_time"] = t
+
+    df = pd.DataFrame(records.values())
+    # Extract class letter
+    df["goes_class_letter"] = df["goes_class"].str.extract(r"^([ABCMX])", expand=False)
+    print(f"  {len(df):,} flares from NCEI (GOES-16)")
+    return df
+
+
+def parse_swpc_xra_line(line, date_str):
+    """Parse a single XRA line from SWPC event report."""
+    # Format: Event# +/-  Begin  Max   End  Obs Q Type Loc/Frq  Particulars  Reg#
+    # Example: 2260 +     0024   0029  0035  G18  5   XRA  1-8A  C3.2  2.5E-03  4392
+    parts = line.split()
+    if len(parts) < 11:
+        return None
+
+    try:
+        # Find XRA position to anchor parsing
+        xra_idx = parts.index("XRA")
+        # Begin/Max/End are 3 fields before the observatory
+        # Work backwards from XRA: parts[xra_idx-3] = Obs, parts[xra_idx-4] = End, etc.
+        # Actually, the fields before XRA are: Begin Max End Obs Quality XRA
+        # So: Obs = parts[xra_idx-2], Quality = parts[xra_idx-1]... no.
+        # Format is fixed-width. Let's use column positions instead.
+    except ValueError:
+        return None
+
+    # Fixed-width columns from the SWPC format
+    try:
+        begin = line[14:18].strip()
+        max_t = line[21:25].strip()
+        end = line[30:34].strip()
+
+        # Particulars: class and flux after the Loc/Frq column
+        after_xra = line[line.index("XRA") + 3:].strip()
+        # Format: "1-8A      C3.2    2.5E-03   4392"
+        match = re.search(r"([ABCMX]\d+\.?\d*)\s+([\d.E+-]+)", after_xra)
+        if not match:
+            return None
+
+        goes_class = match.group(1)
+        peak_flux = float(match.group(2))
+
+        # Parse times
+        year = int(date_str[:4])
+        month = int(date_str[4:6])
+        day = int(date_str[6:8])
+
+        def parse_hhmm(hhmm):
+            if not hhmm or hhmm == "////" or not hhmm.replace("A", "").isdigit():
+                return None
+            h = int(hhmm[:2]) if len(hhmm) == 4 else int(hhmm[0])
+            m = int(hhmm[-2:])
+            return datetime(year, month, day, h, m)
+
+        # Extract region number (last numeric field)
+        reg_match = re.search(r"(\d{4})\s*$", after_xra)
+        active_region = int(reg_match.group(1)) if reg_match else None
+
+        return {
+            "start_time": parse_hhmm(begin),
+            "peak_time": parse_hhmm(max_t),
+            "end_time": parse_hhmm(end),
+            "goes_class": goes_class,
+            "goes_class_letter": goes_class[0],
+            "peak_flux_wm2": peak_flux,
+            "active_region": active_region,
+            "satellite": "GOES-18",
+        }
+    except (ValueError, IndexError):
+        return None
+
+
+def fetch_swpc_daily_flares():
+    """Fetch and parse today's SWPC event report for XRA (X-ray flare) events."""
+    print("  Fetching SWPC daily event report...")
+    resp = requests.get(SWPC_EVENTS, timeout=30)
+    resp.raise_for_status()
+    lines = resp.text.splitlines()
+
+    # Extract date from header
+    date_str = None
+    for line in lines:
+        match = re.search(r":Date:\s+(\d{4})\s+(\d{2})\s+(\d{2})", line)
+        if match:
+            date_str = match.group(1) + match.group(2) + match.group(3)
+            break
+
+    if not date_str:
+        print("  Could not parse date from SWPC report")
+        return pd.DataFrame()
+
+    records = []
+    for line in lines:
+        if "XRA" in line and not line.startswith("#"):
+            rec = parse_swpc_xra_line(line, date_str)
+            if rec:
+                records.append(rec)
+
+    df = pd.DataFrame(records) if records else pd.DataFrame()
+    print(f"  {len(df)} flares from SWPC daily report ({date_str})")
+    return df
+
+
+def main():
+    print("Fetching solar flare events...")
+
+    # 1. NCEI GOES-16 bulk data
+    ncei_df = fetch_ncei_flares()
+
+    # 2. SWPC daily supplement
+    swpc_df = fetch_swpc_daily_flares()
+
+    # 3. Merge: add SWPC flares that are after the NCEI end date
+    if not swpc_df.empty and not ncei_df.empty:
+        ncei_end = ncei_df["peak_time"].max()
+        new_flares = swpc_df[swpc_df["peak_time"] > ncei_end]
+        if not new_flares.empty:
+            print(f"  Adding {len(new_flares)} recent flares from SWPC")
+            df = pd.concat([ncei_df, new_flares], ignore_index=True)
+        else:
+            df = ncei_df
+    else:
+        df = ncei_df
+
+    # Clean up
+    df = df.sort_values("start_time").reset_index(drop=True)
+    df = df.drop(columns=["flare_id"], errors="ignore")
+
+    # Ensure proper types
+    for col in ["start_time", "peak_time", "end_time"]:
+        df[col] = pd.to_datetime(df[col], errors="coerce")
+    df["peak_flux_wm2"] = pd.to_numeric(df["peak_flux_wm2"], errors="coerce")
+    df["active_region"] = pd.to_numeric(df["active_region"], errors="coerce").astype("Int64")
+
+    # Stats
+    n_total = len(df)
+    n_c = int((df["goes_class_letter"] == "C").sum())
+    n_m = int((df["goes_class_letter"] == "M").sum())
+    n_x = int((df["goes_class_letter"] == "X").sum())
+    date_min = df["start_time"].min().strftime("%Y-%m-%d")
+    date_max = df["start_time"].max().strftime("%Y-%m-%d")
+
+    strongest = df.loc[df["peak_flux_wm2"].idxmax()]
+    strongest_class = strongest["goes_class"]
+    strongest_date = strongest["peak_time"].strftime("%Y-%m-%d %H:%M")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        data_dir = tmp / "data"
+        data_dir.mkdir()
+
+        out = data_dir / "solar_flare_events.parquet"
+        df.to_parquet(out, index=False, engine="pyarrow", compression="zstd")
+        size_mb = out.stat().st_size / 1024 / 1024
+        print(f"  {size_mb:.1f} MB parquet")
+
+        (tmp / "README.md").write_text(f"""---
+license: mit
+task_categories:
+  - tabular-classification
+  - time-series-forecasting
+tags:
+  - space
+  - solar-flare
+  - goes
+  - space-weather
+  - noaa
+size_categories:
+  - 10K<n<100K
+---
+
+# Solar Flare Events
+
+![Update Solar Flares](https://github.com/juliensimon/space-datasets/actions/workflows/update-solar-flares.yml/badge.svg)
+![Updated](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['solar-flares']&label=updated&color=brightgreen)
+
+Individual solar flare detections from GOES X-ray sensors, spanning **{date_min}** to
+**{date_max}**. Currently **{n_total:,}** flare events from GOES-16, supplemented with
+near-real-time detections from NOAA SWPC.
+
+## Dataset description
+
+Solar flares are sudden bursts of electromagnetic radiation from the Sun. They are
+classified by peak X-ray flux in the 1-8 Angstrom band: **B** (< 10⁻⁶ W/m²),
+**C** (10⁻⁶), **M** (10⁻⁵), and **X** (10⁻⁴ W/m²). M and X-class flares can
+cause radio blackouts, GPS errors, satellite anomalies, and geomagnetic storms
+that increase atmospheric drag on LEO satellites.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `start_time` | datetime | Flare start time (UTC) |
+| `peak_time` | datetime | Flare peak time (UTC) |
+| `end_time` | datetime | Flare end time (UTC) |
+| `goes_class` | string | GOES class (e.g. "B3.7", "C1.6", "M5.1", "X1.0") |
+| `goes_class_letter` | string | Class letter: B, C, M, or X |
+| `peak_flux_wm2` | float64 | Peak X-ray flux in 1-8A band (W/m²) |
+| `active_region` | int | NOAA active region number (when available) |
+| `satellite` | string | Source satellite (GOES-16, GOES-18) |
+
+## Quick stats
+
+- **{n_total:,}** flare events ({date_min} to {date_max})
+- **{n_c:,}** C-class, **{n_m:,}** M-class, **{n_x:,}** X-class flares
+- Strongest flare: **{strongest_class}** on {strongest_date}
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("juliensimon/solar-flare-events", split="train")
+df = ds.to_pandas()
+
+# M and X class flares only
+major = df[df["goes_class_letter"].isin(["M", "X"])]
+
+# Flare frequency over time
+df["month"] = df["start_time"].dt.to_period("M")
+monthly = df.groupby("month").size()
+
+# X-class flares by active region
+x_flares = df[df["goes_class_letter"] == "X"]
+x_flares["active_region"].value_counts().head(10)
+
+# Flare duration
+df["duration_min"] = (df["end_time"] - df["start_time"]).dt.total_seconds() / 60
+```
+
+## Data sources
+
+- **Bulk data**: [NCEI GOES-16 XRS Flare Summary](https://data.ngdc.noaa.gov/platforms/solar-space-observing-satellites/goes/goes16/l2/data/xrsf-l2-flsum_science/) (science-quality, 2017-present)
+- **Daily supplement**: [NOAA SWPC Event Reports](https://www.swpc.noaa.gov/products/solar-and-geophysical-event-reports) (near-real-time)
+
+Pre-2017 backfill from earlier GOES satellites is planned for a future update.
+
+## Update schedule
+
+Daily at 12:00 UTC via [GitHub Actions](https://github.com/juliensimon/space-datasets).
+
+## Related datasets
+
+- [space-weather-indices](https://huggingface.co/datasets/juliensimon/space-weather-indices) — Daily Kp, Ap, F10.7 indices
+- [space-track-satcat](https://huggingface.co/datasets/juliensimon/space-track-satcat) — Full NORAD satellite catalog
+- [neo-close-approaches](https://huggingface.co/datasets/juliensimon/neo-close-approaches) — Near-Earth object approaches
+
+## Pipeline
+
+Source code: [juliensimon/space-datasets](https://github.com/juliensimon/space-datasets)
+
+## License
+
+MIT
+""")
+
+        print("Uploading to HF...")
+        commit_msg = f"Update solar flare events: {n_total:,} flares"
+        subprocess.run(
+            ["hf", "upload", HF_REPO, str(tmp), ".",
+             "--repo-type", "dataset",
+             "--commit-message", commit_msg],
+            check=True,
+        )
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-space-weather.py
+++ b/scripts/update-space-weather.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Fetch space weather indices from CelesTrak and upload to HF."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+
+SW_URL = "https://celestrak.org/SpaceData/SW-All.csv"
+HF_REPO = "juliensimon/space-weather-indices"
+
+# NOAA Kp-based storm scale thresholds (max 3-hourly Kp in a day)
+STORM_THRESHOLDS = [(9, "G5"), (8, "G4"), (7, "G3"), (6, "G2"), (5, "G1")]
+
+
+def classify_storm(row):
+    """Classify geomagnetic storm level from max Kp value."""
+    kp_cols = [c for c in row.index if c.startswith("kp_") and c != "kp_sum"]
+    kp_max = row[kp_cols].max()
+    if pd.isna(kp_max):
+        return None
+    for threshold, level in STORM_THRESHOLDS:
+        if kp_max >= threshold:
+            return level
+    return None
+
+
+def main():
+    print("Fetching space weather indices from CelesTrak...")
+    df = pd.read_csv(SW_URL)
+    print(f"  {len(df):,} daily records")
+
+    # Type conversions
+    df["DATE"] = pd.to_datetime(df["DATE"], errors="coerce")
+
+    numeric_cols = [c for c in df.columns if c != "DATE" and c != "F10.7_DATA_TYPE"]
+    for col in numeric_cols:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    # Rename columns
+    kp_map = {f"KP{i}": f"kp_{h:02d}00" for i, h in enumerate([0, 3, 6, 9, 12, 15, 18, 21], 1)}
+    ap_map = {f"AP{i}": f"ap_{h:02d}00" for i, h in enumerate([0, 3, 6, 9, 12, 15, 18, 21], 1)}
+
+    rename = {
+        "DATE": "date",
+        "BSRN": "bartels_rotation",
+        "ND": "bartels_day",
+        **kp_map,
+        "KP_SUM": "kp_sum",
+        **ap_map,
+        "AP_AVG": "ap_avg",
+        "CP": "cp",
+        "C9": "c9",
+        "ISN": "sunspot_number",
+        "F10.7_OBS": "f107_obs",
+        "F10.7_ADJ": "f107_adj",
+        "F10.7_DATA_TYPE": "f107_data_type",
+        "F10.7_OBS_CENTER81": "f107_obs_center81",
+        "F10.7_OBS_LAST81": "f107_obs_last81",
+        "F10.7_ADJ_CENTER81": "f107_adj_center81",
+        "F10.7_ADJ_LAST81": "f107_adj_last81",
+    }
+    df = df.rename(columns=rename)
+
+    # Derived columns
+    df["is_storm"] = df["ap_avg"] >= 50
+    df["storm_level"] = df.apply(classify_storm, axis=1)
+    df["data_type"] = df["f107_data_type"].map({
+        "OBS": "observed", "INT": "observed",
+        "PRD": "predicted", "PRM": "predicted",
+    })
+
+    # Stats
+    observed = df[df["data_type"] == "observed"]
+    n_observed = len(observed)
+    n_predicted = len(df) - n_observed
+    n_storms = int(df["is_storm"].sum())
+    n_g3_plus = int(df["storm_level"].isin(["G3", "G4", "G5"]).sum())
+    date_min = df["date"].min().strftime("%Y-%m-%d")
+    date_max_obs = observed["date"].max().strftime("%Y-%m-%d")
+    max_ap = observed["ap_avg"].max()
+    max_ap_date = observed.loc[observed["ap_avg"].idxmax(), "date"].strftime("%Y-%m-%d")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        data_dir = tmp / "data"
+        data_dir.mkdir()
+
+        out = data_dir / "space_weather_indices.parquet"
+        df.to_parquet(out, index=False, engine="pyarrow", compression="zstd")
+        size_mb = out.stat().st_size / 1024 / 1024
+        print(f"  {size_mb:.1f} MB parquet")
+
+        (tmp / "README.md").write_text(f"""---
+license: mit
+task_categories:
+  - tabular-regression
+  - time-series-forecasting
+tags:
+  - space
+  - space-weather
+  - geomagnetic
+  - solar
+  - noaa
+  - celestrak
+size_categories:
+  - 10K<n<100K
+---
+
+# Space Weather Indices
+
+![Update Space Weather](https://github.com/juliensimon/space-datasets/actions/workflows/update-space-weather.yml/badge.svg)
+![Updated](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['space-weather']&label=updated&color=brightgreen)
+
+Daily geomagnetic and solar indices from [CelesTrak](https://celestrak.org/SpaceData/),
+which mirrors NOAA Space Weather Prediction Center data. Covers **{date_min}** to present
+with **{n_observed:,}** observed days plus **{n_predicted:,}** days of predictions/forecasts.
+
+## Dataset description
+
+This dataset contains the fundamental indices used to characterize space weather conditions:
+
+- **Kp/Ap indices** — Planetary geomagnetic activity (3-hourly and daily). Higher values indicate
+  stronger geomagnetic storms that cause satellite drag, GPS errors, and power grid disturbances.
+- **F10.7 solar radio flux** — Proxy for solar EUV radiation that heats the upper atmosphere,
+  directly affecting satellite drag and orbital decay rates.
+- **International Sunspot Number** — Long-running indicator of solar activity cycle.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `date` | datetime | Observation date |
+| `bartels_rotation` | int | Bartels Solar Rotation Number (27-day cycle since 1832) |
+| `bartels_day` | int | Day within Bartels cycle (1-27) |
+| `kp_0000`–`kp_2100` | float | 3-hourly Kp index for each UT interval |
+| `kp_sum` | float | Sum of eight daily Kp values |
+| `ap_0000`–`ap_2100` | int | 3-hourly Ap index for each UT interval |
+| `ap_avg` | float | Daily average Ap index |
+| `cp` | float | Daily Character Figure (0-2.5) |
+| `c9` | int | Converted Cp (0-9 scale) |
+| `sunspot_number` | int | International Sunspot Number |
+| `f107_obs` | float | Observed 10.7cm solar radio flux (sfu) |
+| `f107_adj` | float | F10.7 adjusted to 1 AU |
+| `f107_data_type` | string | Source: OBS (observed), INT (interpolated), PRD/PRM (predicted) |
+| `f107_obs_center81` | float | 81-day centered average (observed) |
+| `f107_obs_last81` | float | 81-day trailing average (observed) |
+| `f107_adj_center81` | float | 81-day centered average (adjusted) |
+| `f107_adj_last81` | float | 81-day trailing average (adjusted) |
+| `is_storm` | bool | Geomagnetic storm flag (daily Ap >= 50) |
+| `storm_level` | string | NOAA G-scale: G1 (minor) to G5 (extreme), based on max Kp |
+| `data_type` | string | "observed" or "predicted" |
+
+## Quick stats
+
+- **{n_observed:,}** observed days ({date_min} to {date_max_obs})
+- **{n_storms:,}** geomagnetic storm days (Ap >= 50)
+- **{n_g3_plus:,}** severe storms (G3+)
+- Strongest storm: Ap={max_ap:.0f} on {max_ap_date}
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("juliensimon/space-weather-indices", split="train")
+df = ds.to_pandas()
+
+# Only observed data (exclude predictions)
+observed = df[df["data_type"] == "observed"]
+
+# Geomagnetic storms
+storms = df[df["is_storm"] == True].sort_values("ap_avg", ascending=False)
+
+# Solar cycle visualization
+df["year"] = df["date"].dt.year
+yearly_ssn = df.groupby("year")["sunspot_number"].mean()
+
+# F10.7 flux trend (drives atmospheric drag)
+df.set_index("date")[["f107_adj"]].rolling(81).mean().plot()
+
+# Storm frequency by solar cycle phase
+df["cycle_phase"] = df["sunspot_number"].rolling(365).mean()
+```
+
+## Data source
+
+[CelesTrak Space Weather Data](https://celestrak.org/SpaceData/), maintained by Dr. T.S. Kelso,
+mirroring NOAA SWPC and GFZ Potsdam geomagnetic indices. The original indices are produced by the
+International Service of Geomagnetic Indices (ISGI) and NOAA Space Weather Prediction Center.
+
+## Update schedule
+
+Daily at 11:00 UTC via [GitHub Actions](https://github.com/juliensimon/space-datasets).
+
+## Related datasets
+
+- [solar-flare-events](https://huggingface.co/datasets/juliensimon/solar-flare-events) — Individual solar flare detections from GOES
+- [space-track-satcat](https://huggingface.co/datasets/juliensimon/space-track-satcat) — Full NORAD satellite catalog
+- [space-track-tle-history](https://huggingface.co/datasets/juliensimon/space-track-tle-history) — 232M historical TLE records
+- [neo-close-approaches](https://huggingface.co/datasets/juliensimon/neo-close-approaches) — Near-Earth object approaches
+
+## Pipeline
+
+Source code: [juliensimon/space-datasets](https://github.com/juliensimon/space-datasets)
+
+## License
+
+MIT
+""")
+
+        print("Uploading to HF...")
+        commit_msg = f"Update space weather indices: {n_observed:,} observed days"
+        subprocess.run(
+            ["hf", "upload", HF_REPO, str(tmp), ".",
+             "--repo-type", "dataset",
+             "--commit-message", commit_msg],
+            check=True,
+        )
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Space Weather Indices** (`scripts/update-space-weather.py`): Daily Kp, Ap, F10.7, sunspot numbers from CelesTrak CSV (1957–present, 25K+ daily records). Runs daily at 11:00 UTC.
- **Solar Flare Events** (`scripts/update-solar-flares.py`): GOES-16 X-ray flare catalog from NCEI NetCDF + SWPC daily text supplement (2017–present, 16K+ flares). Runs daily at 12:00 UTC.
- Both datasets uploaded and live from local test runs
- Pre-2017 flare backfill planned for later

## Test plan
- [ ] Trigger `update-space-weather` workflow and confirm green run
- [ ] Trigger `update-solar-flares` workflow and confirm green run
- [ ] Verify both HF dataset pages show correct schema and preview
- [ ] Verify `status.json` gets `space-weather` and `solar-flares` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)