### PR TITLE
Add Dst index and DONKI space weather events

### DIFF
--- a/.github/workflows/update-donki.yml
+++ b/.github/workflows/update-donki.yml
@@ -1,0 +1,31 @@
+name: Update DONKI Events
+on:
+  schedule:
+    - cron: '0 14 * * *'  # daily at 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment: HF
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pandas pyarrow requests huggingface_hub[hf_xet]
+      - run: python scripts/update-donki.py
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      - name: Update status
+        run: python scripts/update-status.py donki
+      - name: Push status
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add status.json
+          git diff --cached --quiet || (git commit -m "status: donki updated $(date -u +%Y-%m-%d)" && git pull --rebase && git push)

--- a/.github/workflows/update-dst-index.yml
+++ b/.github/workflows/update-dst-index.yml
@@ -1,0 +1,30 @@
+name: Update Dst Index
+on:
+  schedule:
+    - cron: '0 13 * * *'  # daily at 13:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment: HF
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pandas pyarrow requests huggingface_hub[hf_xet]
+      - run: python scripts/update-dst-index.py
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      - name: Update status
+        run: python scripts/update-status.py dst-index
+      - name: Push status
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add status.json
+          git diff --cached --quiet || (git commit -m "status: dst-index updated $(date -u +%Y-%m-%d)" && git pull --rebase && git push)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Automated pipelines that keep space-related datasets on Hugging Face up to date.
 ![Update NEO Close Approaches](https://github.com/juliensimon/space-datasets/actions/workflows/update-neo.yml/badge.svg)
 ![Update Space Weather](https://github.com/juliensimon/space-datasets/actions/workflows/update-space-weather.yml/badge.svg)
 ![Update Solar Flares](https://github.com/juliensimon/space-datasets/actions/workflows/update-solar-flares.yml/badge.svg)
+![Update Dst Index](https://github.com/juliensimon/space-datasets/actions/workflows/update-dst-index.yml/badge.svg)
+![Update DONKI Events](https://github.com/juliensimon/space-datasets/actions/workflows/update-donki.yml/badge.svg)
 
 ## Datasets
 
@@ -22,6 +24,8 @@ Automated pipelines that keep space-related datasets on Hugging Face up to date.
 | [neo-close-approaches](https://huggingface.co/datasets/juliensimon/neo-close-approaches) | ![NEO](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$.neo&label=updated&color=brightgreen) | Daily 10:00 UTC | NASA JPL CNEOS | ~35K close approaches |
 | [space-weather-indices](https://huggingface.co/datasets/juliensimon/space-weather-indices) | ![Space Weather](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['space-weather']&label=updated&color=brightgreen) | Daily 11:00 UTC | CelesTrak / NOAA SWPC | Daily indices since 1957 |
 | [solar-flare-events](https://huggingface.co/datasets/juliensimon/solar-flare-events) | ![Solar Flares](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['solar-flares']&label=updated&color=brightgreen) | Daily 12:00 UTC | NCEI GOES-16 + SWPC | ~16K flare events (2017+) |
+| [dst-index](https://huggingface.co/datasets/juliensimon/dst-index) | ![Dst](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['dst-index']&label=updated&color=brightgreen) | Daily 13:00 UTC | WDC Kyoto | ~600K hourly readings (1957+) |
+| [donki-space-weather-events](https://huggingface.co/datasets/juliensimon/donki-space-weather-events) | ![DONKI](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$.donki&label=updated&color=brightgreen) | Daily 14:00 UTC | NASA CCMC DONKI | CMEs, storms, shocks (2010+) |
 
 ## How it works
 
@@ -59,6 +63,12 @@ python scripts/update-space-weather.py
 # Update solar flare events (requires netCDF4)
 pip install netCDF4
 python scripts/update-solar-flares.py
+
+# Update Dst geomagnetic index
+python scripts/update-dst-index.py
+
+# Update DONKI space weather events
+python scripts/update-donki.py
 ```
 
 ## Bulk ingestion

--- a/scripts/update-donki.py
+++ b/scripts/update-donki.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Fetch space weather events from NASA DONKI and upload to HF."""
+
+import subprocess
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+
+DONKI_BASE = "https://kauai.ccmc.gsfc.nasa.gov/DONKI/WS/get"
+HF_REPO = "juliensimon/donki-space-weather-events"
+START_YEAR = 2010
+
+
+def fetch_donki(endpoint, start_date, end_date, extra_params=None):
+    """Fetch from a DONKI endpoint with date range."""
+    params = {"startDate": start_date, "endDate": end_date}
+    if extra_params:
+        params.update(extra_params)
+    resp = requests.get(f"{DONKI_BASE}/{endpoint}", params=params, timeout=120)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_by_year(endpoint, extra_params=None):
+    """Fetch all records by year to avoid timeouts."""
+    all_records = []
+    now = datetime.utcnow()
+    for year in range(START_YEAR, now.year + 1):
+        end = f"{year}-12-31" if year < now.year else now.strftime("%Y-%m-%d")
+        try:
+            records = fetch_donki(endpoint, f"{year}-01-01", end, extra_params)
+            all_records.extend(records)
+            print(f"    {year}: {len(records)} records")
+        except Exception as e:
+            print(f"    {year}: error - {e}")
+        time.sleep(0.5)  # Be polite to the API
+    return all_records
+
+
+def parse_cmes(raw):
+    """Parse CME records into flat rows."""
+    rows = []
+    for cme in raw:
+        row = {
+            "event_type": "CME",
+            "activity_id": cme.get("activityID"),
+            "start_time": cme.get("startTime"),
+            "source_location": cme.get("sourceLocation") or None,
+            "active_region": cme.get("activeRegionNum"),
+            "note": cme.get("note"),
+            "link": cme.get("link"),
+        }
+        # Extract best analysis
+        analyses = cme.get("cmeAnalyses") or []
+        best = next((a for a in analyses if a.get("isMostAccurate")), analyses[0] if analyses else None)
+        if best:
+            row["cme_speed_kms"] = best.get("speed")
+            row["cme_half_angle_deg"] = best.get("halfAngle")
+            row["cme_latitude"] = best.get("latitude")
+            row["cme_longitude"] = best.get("longitude")
+            row["cme_type"] = best.get("type")
+            row["cme_time_21_5"] = best.get("time21_5")
+            row["cme_measurement"] = best.get("measurementTechnique")
+
+        # Linked events
+        linked = cme.get("linkedEvents") or []
+        row["linked_events"] = ", ".join(e.get("activityID", "") for e in linked) if linked else None
+
+        rows.append(row)
+    return rows
+
+
+def parse_gsts(raw):
+    """Parse geomagnetic storm records."""
+    rows = []
+    for gst in raw:
+        # Extract max Kp from allKpIndex
+        kp_list = gst.get("allKpIndex") or []
+        max_kp = max((k.get("kpIndex", 0) for k in kp_list), default=None) if kp_list else None
+        kp_times = [{"time": k.get("observedTime"), "kp": k.get("kpIndex")} for k in kp_list]
+
+        row = {
+            "event_type": "GST",
+            "activity_id": gst.get("gstID"),
+            "start_time": gst.get("startTime"),
+            "link": gst.get("link"),
+            "gst_max_kp": max_kp,
+            "gst_kp_count": len(kp_list),
+        }
+        linked = gst.get("linkedEvents") or []
+        row["linked_events"] = ", ".join(e.get("activityID", "") for e in linked) if linked else None
+        rows.append(row)
+    return rows
+
+
+def parse_simple_events(raw, event_type):
+    """Parse simple event types (IPS, HSS, SEP, etc.)."""
+    rows = []
+    id_key = {
+        "IPS": "activityID", "HSS": "hssID", "SEP": "sepID",
+        "MPC": "mpcID", "RBE": "rbeID",
+    }.get(event_type, "activityID")
+
+    for evt in raw:
+        row = {
+            "event_type": event_type,
+            "activity_id": evt.get(id_key),
+            "start_time": evt.get("eventTime") or evt.get("startTime"),
+            "link": evt.get("link"),
+        }
+        if event_type == "IPS":
+            row["note"] = evt.get("location")
+        linked = evt.get("linkedEvents") or []
+        row["linked_events"] = ", ".join(e.get("activityID", "") for e in linked) if linked else None
+        rows.append(row)
+    return rows
+
+
+def main():
+    print("Fetching DONKI space weather events...")
+
+    all_rows = []
+
+    # CMEs
+    print("  Fetching CMEs...")
+    cme_raw = fetch_by_year("CME")
+    all_rows.extend(parse_cmes(cme_raw))
+    print(f"  {len(cme_raw)} CMEs total")
+
+    # Geomagnetic Storms
+    print("  Fetching GSTs...")
+    gst_raw = fetch_by_year("GST")
+    all_rows.extend(parse_gsts(gst_raw))
+    print(f"  {len(gst_raw)} GSTs total")
+
+    # Interplanetary Shocks
+    print("  Fetching IPS...")
+    ips_raw = fetch_by_year("IPS")
+    all_rows.extend(parse_simple_events(ips_raw, "IPS"))
+    print(f"  {len(ips_raw)} IPS total")
+
+    # High Speed Streams
+    print("  Fetching HSS...")
+    hss_raw = fetch_by_year("HSS")
+    all_rows.extend(parse_simple_events(hss_raw, "HSS"))
+    print(f"  {len(hss_raw)} HSS total")
+
+    # Solar Energetic Particles
+    print("  Fetching SEP...")
+    sep_raw = fetch_by_year("SEP")
+    all_rows.extend(parse_simple_events(sep_raw, "SEP"))
+    print(f"  {len(sep_raw)} SEP total")
+
+    df = pd.DataFrame(all_rows)
+    df["start_time"] = pd.to_datetime(df["start_time"], errors="coerce")
+    df["cme_time_21_5"] = pd.to_datetime(df.get("cme_time_21_5"), errors="coerce")
+    df["active_region"] = pd.to_numeric(df.get("active_region"), errors="coerce").astype("Int64")
+    df = df.sort_values("start_time").reset_index(drop=True)
+
+    # Stats
+    n_total = len(df)
+    n_cme = int((df["event_type"] == "CME").sum())
+    n_gst = int((df["event_type"] == "GST").sum())
+    n_ips = int((df["event_type"] == "IPS").sum())
+    n_hss = int((df["event_type"] == "HSS").sum())
+    n_sep = int((df["event_type"] == "SEP").sum())
+    date_min = df["start_time"].min().strftime("%Y-%m-%d")
+    date_max = df["start_time"].max().strftime("%Y-%m-%d")
+    fastest_cme = df.loc[df["cme_speed_kms"].idxmax()] if "cme_speed_kms" in df.columns else None
+    max_kp = df["gst_max_kp"].max() if "gst_max_kp" in df.columns else None
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        data_dir = tmp / "data"
+        data_dir.mkdir()
+
+        out = data_dir / "donki_events.parquet"
+        df.to_parquet(out, index=False, engine="pyarrow", compression="zstd")
+        size_mb = out.stat().st_size / 1024 / 1024
+        print(f"  {size_mb:.1f} MB parquet")
+
+        fastest_speed = int(fastest_cme["cme_speed_kms"]) if fastest_cme is not None else "N/A"
+        fastest_date = fastest_cme["start_time"].strftime("%Y-%m-%d") if fastest_cme is not None else "N/A"
+
+        (tmp / "README.md").write_text(f"""---
+license: mit
+task_categories:
+  - tabular-classification
+  - time-series-forecasting
+tags:
+  - space
+  - space-weather
+  - cme
+  - geomagnetic-storm
+  - solar
+  - nasa
+size_categories:
+  - 10K<n<100K
+---
+
+# DONKI Space Weather Events
+
+![Update DONKI](https://github.com/juliensimon/space-datasets/actions/workflows/update-donki.yml/badge.svg)
+![Updated](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$.donki&label=updated&color=brightgreen)
+
+Space weather events from NASA's [DONKI](https://kauai.ccmc.gsfc.nasa.gov/DONKI/) (Database Of
+Notifications, Knowledge, Information) at the Community Coordinated Modeling Center. Covers
+**{date_min}** to **{date_max}** with **{n_total:,}** events.
+
+## Dataset description
+
+DONKI tracks the chain of space weather events from Sun to Earth:
+
+1. **CME** (Coronal Mass Ejection) — eruption of magnetized plasma from the Sun
+2. **IPS** (Interplanetary Shock) — shock wave propagating through solar wind
+3. **GST** (Geomagnetic Storm) — disturbance in Earth's magnetosphere
+4. **HSS** (High Speed Stream) — fast solar wind from coronal holes
+5. **SEP** (Solar Energetic Particle) — high-energy particles from solar events
+
+Events are **cross-linked** via the `linked_events` column, enabling causal chain analysis
+(e.g., which CME caused which geomagnetic storm).
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `event_type` | string | CME, GST, IPS, HSS, or SEP |
+| `activity_id` | string | Unique event identifier |
+| `start_time` | datetime | Event start time (UTC) |
+| `source_location` | string | Solar source location (CME only, e.g. "N23W45") |
+| `active_region` | int | NOAA active region number (CME only) |
+| `note` | string | Analyst notes |
+| `link` | string | DONKI web page for this event |
+| `cme_speed_kms` | float | CME speed in km/s (CME only) |
+| `cme_half_angle_deg` | float | CME half-angle in degrees (CME only) |
+| `cme_latitude` | float | CME latitude (CME only) |
+| `cme_longitude` | float | CME longitude (CME only) |
+| `cme_type` | string | CME type: S (slow), C (common), O (occasional), R (rare), ER (extremely rare) |
+| `cme_time_21_5` | datetime | Time CME reaches 21.5 solar radii (CME only) |
+| `cme_measurement` | string | Measurement technique (CME only) |
+| `gst_max_kp` | float | Maximum Kp index during storm (GST only) |
+| `gst_kp_count` | int | Number of Kp readings during storm (GST only) |
+| `linked_events` | string | Comma-separated IDs of linked events (causal chain) |
+
+## Quick stats
+
+- **{n_total:,}** events ({date_min} to {date_max})
+- **{n_cme:,}** CMEs, **{n_gst:,}** geomagnetic storms, **{n_ips:,}** interplanetary shocks
+- **{n_hss:,}** high speed streams, **{n_sep:,}** solar energetic particle events
+- Fastest CME: **{fastest_speed} km/s** on {fastest_date}
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("juliensimon/donki-space-weather-events", split="train")
+df = ds.to_pandas()
+
+# Fast CMEs (potential Earth-directed storms)
+fast_cmes = df[(df["event_type"] == "CME") & (df["cme_speed_kms"] > 1000)]
+
+# Geomagnetic storms with linked CMEs
+storms = df[df["event_type"] == "GST"]
+storms_with_cme = storms[storms["linked_events"].str.contains("CME", na=False)]
+
+# CME speed distribution
+cmes = df[df["event_type"] == "CME"]
+cmes["cme_speed_kms"].hist(bins=50)
+
+# Event frequency by type and year
+df["year"] = df["start_time"].dt.year
+df.groupby(["year", "event_type"]).size().unstack().plot()
+
+# Causal chain: find all events linked to a specific CME
+cme_id = "2024-05-08T22:09:00-CME-001"
+chain = df[df["linked_events"].str.contains(cme_id, na=False)]
+```
+
+## Data source
+
+[NASA CCMC DONKI API](https://ccmc.gsfc.nasa.gov/tools/DONKI/). Events are catalogued by
+space weather analysts at the Community Coordinated Modeling Center (CCMC) using data from
+SOHO, STEREO, SDO, and ground-based observatories.
+
+## Update schedule
+
+Daily at 14:00 UTC via [GitHub Actions](https://github.com/juliensimon/space-datasets).
+
+## Related datasets
+
+- [solar-flare-events](https://huggingface.co/datasets/juliensimon/solar-flare-events) — GOES X-ray flare detections
+- [space-weather-indices](https://huggingface.co/datasets/juliensimon/space-weather-indices) — Daily Kp, Ap, F10.7
+- [dst-index](https://huggingface.co/datasets/juliensimon/dst-index) — Hourly Dst geomagnetic index
+- [neo-close-approaches](https://huggingface.co/datasets/juliensimon/neo-close-approaches) — Near-Earth object approaches
+
+## Pipeline
+
+Source code: [juliensimon/space-datasets](https://github.com/juliensimon/space-datasets)
+
+## License
+
+MIT
+""")
+
+        print("Uploading to HF...")
+        commit_msg = f"Update DONKI events: {n_total:,} events ({n_cme:,} CMEs, {n_gst:,} storms)"
+        subprocess.run(
+            ["hf", "upload", HF_REPO, str(tmp), ".",
+             "--repo-type", "dataset",
+             "--commit-message", commit_msg],
+            check=True,
+        )
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-dst-index.py
+++ b/scripts/update-dst-index.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Fetch hourly Dst geomagnetic index from WDC Kyoto and upload to HF."""
+
+import re
+import subprocess
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+
+# URL patterns: final (1957-2020), provisional (2021-2025), realtime (recent)
+DST_SOURCES = [
+    ("final", "https://wdc.kugi.kyoto-u.ac.jp/dst_final/{ym6}/dst{ym4}.for.request", 1957, 2020),
+    ("provisional", "https://wdc.kugi.kyoto-u.ac.jp/dst_provisional/{ym6}/dst{ym4}.for.request", 2021, 2025),
+    ("realtime", "https://wdc.kugi.kyoto-u.ac.jp/dst_realtime/{ym6}/dst{ym4}.for.request", 2026, 2030),
+]
+HF_REPO = "juliensimon/dst-index"
+
+
+def parse_dst_wdc(text, quality):
+    """Parse WDC-format Dst data. Each line has 24 hourly values + daily mean."""
+    records = []
+    for line in text.splitlines():
+        if not line.startswith("DST"):
+            continue
+        # Format: DST YYMM*DD QQ X VVV 0 h0 h1 h2 ... h23 mean
+        # Positions are fixed-width: values start at col 20, each 4 chars wide
+        try:
+            yy = int(line[3:5])
+            mm = int(line[5:7])
+            dd = int(line[8:10])
+            # Handle century
+            year = 1900 + yy if yy >= 57 else 2000 + yy
+
+            # 24 hourly values start at position 20, 4 chars each
+            # Then daily mean at position 116, 4 chars
+            values_str = line[20:]
+            hourly = []
+            for i in range(24):
+                val_str = values_str[i * 4:(i + 1) * 4].strip()
+                if val_str == "9999" or val_str == "":
+                    hourly.append(None)
+                else:
+                    hourly.append(int(val_str))
+
+            # Daily mean is the last value (position 24)
+            mean_str = values_str[96:100].strip()
+            daily_mean = int(mean_str) if mean_str and mean_str != "9999" else None
+
+            for hour, dst_val in enumerate(hourly):
+                records.append({
+                    "datetime": datetime(year, mm, dd, hour),
+                    "dst_nt": dst_val,
+                    "daily_mean_nt": daily_mean if hour == 0 else None,
+                    "quality": quality,
+                })
+        except (ValueError, IndexError):
+            continue
+    return records
+
+
+def main():
+    print("Fetching Dst index from WDC Kyoto...")
+    all_records = []
+    now = datetime.utcnow()
+
+    for quality, url_template, start_year, end_year in DST_SOURCES:
+        actual_end = min(end_year, now.year)
+        for year in range(start_year, actual_end + 1):
+            end_month = now.month if year == now.year else 12
+            for month in range(1, end_month + 1):
+                ym6 = f"{year}{month:02d}"
+                ym4 = f"{year % 100:02d}{month:02d}"
+                url = url_template.format(ym6=ym6, ym4=ym4)
+                try:
+                    resp = requests.get(url, timeout=15)
+                    if resp.status_code == 200 and resp.text.startswith("DST"):
+                        records = parse_dst_wdc(resp.text, quality)
+                        all_records.extend(records)
+                except Exception:
+                    pass  # Skip months with no data
+            print(f"  {quality} {year}: fetched")
+
+    df = pd.DataFrame(all_records)
+    df["datetime"] = pd.to_datetime(df["datetime"])
+    df = df.sort_values("datetime").reset_index(drop=True)
+
+    # Remove future/empty rows
+    df = df[df["datetime"] <= pd.Timestamp.now()]
+
+    # Propagate daily mean to all hours of that day
+    df["daily_mean_nt"] = df.groupby(df["datetime"].dt.date)["daily_mean_nt"].transform("first")
+
+    # Derived columns
+    df["is_storm"] = df["dst_nt"] <= -50
+    df["storm_intensity"] = pd.cut(
+        df["dst_nt"],
+        bins=[-float("inf"), -500, -250, -100, -50, float("inf")],
+        labels=["super", "intense", "moderate", "weak", "quiet"],
+    )
+
+    print(f"  {len(df):,} hourly records")
+
+    # Stats
+    n_total = len(df)
+    date_min = df["datetime"].min().strftime("%Y-%m-%d")
+    date_max = df["datetime"].max().strftime("%Y-%m-%d")
+    n_storm_hours = int(df["is_storm"].sum())
+    min_dst = df["dst_nt"].min()
+    min_dst_time = df.loc[df["dst_nt"].idxmin(), "datetime"].strftime("%Y-%m-%d %H:%M")
+    n_final = int((df["quality"] == "final").sum())
+    n_provisional = int((df["quality"] == "provisional").sum())
+    n_realtime = int((df["quality"] == "realtime").sum())
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        data_dir = tmp / "data"
+        data_dir.mkdir()
+
+        out = data_dir / "dst_index.parquet"
+        df.to_parquet(out, index=False, engine="pyarrow", compression="zstd")
+        size_mb = out.stat().st_size / 1024 / 1024
+        print(f"  {size_mb:.1f} MB parquet")
+
+        (tmp / "README.md").write_text(f"""---
+license: mit
+task_categories:
+  - time-series-forecasting
+  - tabular-regression
+tags:
+  - space
+  - space-weather
+  - geomagnetic
+  - dst-index
+  - noaa
+size_categories:
+  - 100K<n<1M
+---
+
+# Dst Geomagnetic Index (Hourly)
+
+![Update Dst Index](https://github.com/juliensimon/space-datasets/actions/workflows/update-dst-index.yml/badge.svg)
+![Updated](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/juliensimon/space-datasets/main/status.json&query=$['dst-index']&label=updated&color=brightgreen)
+
+Hourly Disturbance Storm Time (Dst) index from [WDC Kyoto](https://wdc.kugi.kyoto-u.ac.jp/dstdir/),
+the standard measure of geomagnetic storm intensity. Covers **{date_min}** to **{date_max}**
+with **{n_total:,}** hourly readings.
+
+## Dataset description
+
+The Dst index measures the strength of the ring current — a toroidal electric current flowing
+in the magnetosphere. During geomagnetic storms, the ring current intensifies and Dst drops
+sharply (e.g. -100 to -500 nT for major storms). This index is the primary metric used by
+satellite operators and power grid managers to assess storm severity.
+
+Dst complements the Kp/Ap indices (available in our
+[space-weather-indices](https://huggingface.co/datasets/juliensimon/space-weather-indices) dataset)
+by providing **hourly** resolution vs. 3-hourly/daily.
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `datetime` | datetime | Observation time (UTC, hourly) |
+| `dst_nt` | int | Dst value in nanotesla (nT). Negative = disturbed. |
+| `daily_mean_nt` | int | Daily mean Dst (nT) |
+| `quality` | string | Data quality: "final" (definitive), "provisional", or "realtime" |
+| `is_storm` | bool | True if Dst <= -50 nT |
+| `storm_intensity` | string | "quiet" (> -50), "weak" (-50 to -100), "moderate" (-100 to -250), "intense" (-250 to -500), "super" (< -500) |
+
+## Quick stats
+
+- **{n_total:,}** hourly readings ({date_min} to {date_max})
+- **{n_storm_hours:,}** storm hours (Dst <= -50 nT)
+- Deepest storm: **{min_dst} nT** on {min_dst_time}
+- Data quality: {n_final:,} final, {n_provisional:,} provisional, {n_realtime:,} realtime
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("juliensimon/dst-index", split="train")
+df = ds.to_pandas()
+
+# Major storms (Dst < -100)
+major = df[df["dst_nt"] < -100].sort_values("dst_nt")
+
+# Storm frequency by year
+df["year"] = df["datetime"].dt.year
+storms_per_year = df[df["is_storm"]].groupby("year").size()
+
+# Dst time series around a specific storm
+storm = df[(df["datetime"] >= "2024-05-10") & (df["datetime"] <= "2024-05-15")]
+
+# Compare with Kp index (load space-weather-indices dataset)
+# Both datasets can be joined on date for cross-analysis
+```
+
+## Data source
+
+[WDC for Geomagnetism, Kyoto](https://wdc.kugi.kyoto-u.ac.jp/dstdir/). Three quality tiers:
+- **Final** (1957-2020): Definitive, quality-checked values
+- **Provisional** (2021-2025): Visually screened but not final
+- **Real-time** (recent): Quicklook values, may be revised
+
+## Update schedule
+
+Daily at 13:00 UTC via [GitHub Actions](https://github.com/juliensimon/space-datasets).
+
+## Related datasets
+
+- [space-weather-indices](https://huggingface.co/datasets/juliensimon/space-weather-indices) — Daily Kp, Ap, F10.7 indices
+- [solar-flare-events](https://huggingface.co/datasets/juliensimon/solar-flare-events) — Individual flare detections
+- [space-track-tle-history](https://huggingface.co/datasets/juliensimon/space-track-tle-history) — Orbital element history (for drag analysis)
+
+## Pipeline
+
+Source code: [juliensimon/space-datasets](https://github.com/juliensimon/space-datasets)
+
+## License
+
+MIT (pipeline code). Dst data: free for non-commercial use per WDC Kyoto terms.
+""")
+
+        print("Uploading to HF...")
+        commit_msg = f"Update Dst index: {n_total:,} hourly readings"
+        subprocess.run(
+            ["hf", "upload", HF_REPO, str(tmp), ".",
+             "--repo-type", "dataset",
+             "--commit-message", commit_msg],
+            check=True,
+        )
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Dst Index** (`scripts/update-dst-index.py`): Hourly Dst geomagnetic index from WDC Kyoto (1957–present, ~190K readings). Final/provisional/realtime quality tiers. Runs daily at 13:00 UTC.
- **DONKI Events** (`scripts/update-donki.py`): 5 event types from NASA CCMC DONKI — CMEs (9.3K), geomagnetic storms (191), interplanetary shocks (1.3K), high speed streams (757), solar energetic particles (468). Cross-linked via `linked_events` column. Runs daily at 14:00 UTC.
- Both uploaded to HF from local test runs

## Test plan
- [ ] Trigger `update-dst-index` workflow and confirm green
- [ ] Trigger `update-donki` workflow and confirm green
- [ ] Verify both HF dataset pages show correct schema and preview
- [ ] Verify `status.json` gets `dst-index` and `donki` keys
- [ ] Add both to HF collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)