### PR TITLE
fix(pulsars): derive age locally; harden HEASARC client against error blocks

### DIFF
--- a/scripts/hf_dataset_utils/tap/heasarc.py
+++ b/scripts/hf_dataset_utils/tap/heasarc.py
@@ -11,9 +11,28 @@ import requests
 TAP_URL = "https://heasarc.gsfc.nasa.gov/xamin/vo/tap/sync"
 
 
+def _heasarc_failure(text: str) -> str | None:
+    """Return HEASARC's error message if the response is a query-failure block.
+
+    HEASARC reports query errors as a plain-text ``---- Messages ----`` block
+    with HTTP 200 (not an HTTP error status, and — for FORMAT=text — not XML).
+    The block contains a line beginning with ``Failure:``. Such a block is not
+    tabular data; left unguarded, the text parser turns it into a bogus
+    one-column DataFrame that passes the non-empty check, masking a hard query
+    failure as a cryptic downstream ``KeyError`` on a missing column.
+    """
+    lines = [l.strip() for l in text.splitlines()]
+    if not any(l.startswith("Failure:") for l in lines):
+        return None
+    msg = [l for l in lines if l and l != "---- Messages ----" and set(l) != {"-"}]
+    return " ".join(msg) or "HEASARC query failed"
+
+
 def _parse_text(text: str) -> pd.DataFrame | None:
     """Parse HEASARC pipe-delimited text format."""
     if text.strip().startswith("<?xml") or text.strip().startswith("<VOTABLE"):
+        return None
+    if _heasarc_failure(text) is not None:
         return None
     lines = [l for l in text.strip().split("\n") if l.strip()]
     if len(lines) < 2:
@@ -111,6 +130,12 @@ def heasarc_query(
                     "FORMAT": fmt, "QUERY": adql,
                 }, timeout=timeout)
                 resp.raise_for_status()
+                fail = _heasarc_failure(resp.text)
+                if fail is not None:
+                    # Deterministic query error (e.g. an unqueryable column) —
+                    # retrying won't help, so record it and move to the next format.
+                    errors.append(f"{fmt}: {fail}")
+                    break
                 df = parser(resp.text)
                 if df is not None and len(df) > 0:
                     print(f"  HEASARC ({table}): {len(df):,} rows via {fmt} format")

--- a/scripts/tests/test_heasarc_parser.py
+++ b/scripts/tests/test_heasarc_parser.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Regression test for the HEASARC TAP text parser.
+
+HEASARC reports query failures as a plain-text "---- Messages ----" block
+returned with HTTP 200 (not an error status, not XML for FORMAT=text). Before
+the guard added in heasarc.py, `_parse_text` turned that block into a bogus
+one-column DataFrame which passed the non-empty check, so `heasarc_query`
+returned it as if it were data. Downstream that surfaced as a cryptic
+`KeyError` on a missing column (e.g. update-pulsars.py's `df["period"]`),
+masking the real cause: the query never executed.
+
+This test pins that an error block is recognised and rejected, while a normal
+pipe-delimited table still parses — so any regression is caught locally,
+without a network round-trip, before the weekly cron ships broken data.
+
+Run:
+    python3 scripts/tests/test_heasarc_parser.py
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from hf_dataset_utils.tap.heasarc import _heasarc_failure, _parse_text  # noqa: E402
+
+# Verbatim FORMAT=text body HEASARC returns when a query fails to execute
+# (captured from `SELECT name, age FROM atnfpulsar`, where `age` is a broken
+# server-side column).
+ERROR_BLOCK = "\n---- Messages ----\n----\nFailure: Query Error\nUnable to execute query.\n----\n"
+
+# A normal pipe-delimited result, including the leading/trailing pipes and the
+# dashed separator row HEASARC emits.
+VALID_TABLE = (
+    "name|period|dm\n"
+    "----|------|----\n"
+    "PSR J0002+6216|0.115364|218.6\n"
+    "PSR J0006+1834|0.693748|11.4\n"
+)
+
+
+def test_failure_block_detected():
+    msg = _heasarc_failure(ERROR_BLOCK)
+    assert msg is not None, "error block must be recognised as a failure"
+    assert "Failure: Query Error" in msg, f"message should surface HEASARC's text, got {msg!r}"
+    assert "Unable to execute query." in msg, f"message should include the detail line, got {msg!r}"
+    print(f"PASS: _heasarc_failure detected error block -> {msg!r}")
+
+
+def test_error_block_not_parsed_as_data():
+    # The core bug: an error block must NOT become a DataFrame.
+    assert _parse_text(ERROR_BLOCK) is None, \
+        "error block must not be parsed as a (bogus one-column) DataFrame"
+    print("PASS: _parse_text rejects the HEASARC error block")
+
+
+def test_valid_table_still_parses():
+    df = _parse_text(VALID_TABLE)
+    assert df is not None, "valid pipe table must still parse"
+    assert list(df.columns) == ["name", "period", "dm"], f"columns: {list(df.columns)}"
+    assert len(df) == 2, f"expected 2 data rows (separator skipped), got {len(df)}"
+    # Numeric auto-detection must keep `period` usable for arithmetic downstream.
+    assert df["period"].dtype.kind == "f", f"period should be float, got {df['period'].dtype}"
+    assert _heasarc_failure(VALID_TABLE) is None, "valid data must not be flagged as a failure"
+    print("PASS: _parse_text still parses a normal pipe table (period is numeric)")
+
+
+if __name__ == "__main__":
+    test_failure_block_detected()
+    test_error_block_not_parsed_as_data()
+    test_valid_table_still_parses()
+    print("\nAll tests passed.")

--- a/scripts/update-pulsars.py
+++ b/scripts/update-pulsars.py
@@ -12,9 +12,12 @@ from hf_dataset_utils.tap import heasarc_query
 
 HF_REPO = "juliensimon/pulsar-catalog"
 
+# `age` is derived locally from period/period_dot — HEASARC's native `age`
+# column is currently broken server-side (SELECT on it returns "Query Error"),
+# which would otherwise fail the whole query.
 ADQL = """\
 SELECT name, alt_name, ra, dec, period, period_dot, dm, flux_1400_mhz,
-  companion_type, dm_distance, age, b_surf, e_dot, pulsar_type, pm_tot,
+  companion_type, dm_distance, b_surf, e_dot, pulsar_type, pm_tot,
   discovery_date, assoc_object, binary_model
 FROM atnfpulsar ORDER BY name\
 """
@@ -77,6 +80,13 @@ def main():
     df["is_millisecond"] = df["period"].apply(
         lambda x: True if pd.notna(x) and x < 0.03 else (False if pd.notna(x) else None)
     )
+
+    # Characteristic spin-down age tau = P / (2 * Pdot), in years, computed
+    # locally because HEASARC's native `age` column is unqueryable (see ADQL).
+    # Pdot must be positive; non-positive or null derivatives yield a null age.
+    seconds_per_year = 365.25 * 86400.0
+    pdot = df["period_dot"].where(df["period_dot"] > 0)
+    df["age"] = df["period"] / (2.0 * pdot) / seconds_per_year
 
     # Clean empty strings to NaN for string columns from text format
     for col in ["companion_type", "binary_model", "pulsar_type", "alt_name", "assoc_object"]:


### PR DESCRIPTION
## What & why

Investigating recent workflow failures surfaced one real bug (the rest self-healed). The **Pulsars** pipeline was failing with a cryptic `KeyError: 'period'`. Root cause, verified against live HEASARC:

- HEASARC's `age` column in the `atnfpulsar` table is **broken server-side** — `SELECT TOP 5 age FROM atnfpulsar` returns `Failure: Query Error / Unable to execute query` with **HTTP 200**. Every other column works.
- The failing query made HEASARC return a plain-text `---- Messages ----` block, which `_parse_text` mistook for a 1-column DataFrame. Because it was non-empty, `heasarc_query` returned it as data → `df["period"]` blew up downstream.

## Changes

1. **`update-pulsars.py`** — drop `age` from the ADQL; compute characteristic age `τ = P / (2·Ṗ)` (years) in pandas, with null age where `Ṗ` is non-positive/null. Matches the existing column description.
2. **`hf_dataset_utils/tap/heasarc.py`** — detect HEASARC's `Failure:` message block (HTTP 200) and fail loud with the real message instead of returning bogus data. **Protects every HEASARC-backed dataset** (grb, fermi-4fgl, xray-binary, magnetar, …) from the same silent-failure class.
3. **`tests/test_heasarc_parser.py`** — network-free regression test.

## Verification

- New + existing tests pass.
- End-to-end run of the fixed pipeline against live HEASARC: **4,351 pulsars, no error**; age median ~10 Myr (normal pulsars 10⁴–10⁸ yr ✓); **Crab pulsar = 1,257 yr** vs textbook ~1,240 yr ✓; 2,800/4,351 ages non-null (nulls are pulsars with no measured `Ṗ` ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)