### PR TITLE
Quality-review fixes for the four live datasets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Automated data pipelines that fetch public space data (orbital mechanics, space weather, astronomy, physics), convert to Parquet with zstd compression, and upload to Hugging Face under `juliensimon/`. Currently 207 datasets with 90 GitHub Actions workflows for daily/weekly updates. Static datasets (uploaded once) have no workflow.
+Automated data pipelines that fetch public space data (orbital mechanics, space weather, astronomy, physics), convert to Parquet with zstd compression, and upload to Hugging Face under `juliensimon/`. Currently 230 datasets with 108 GitHub Actions workflows for daily/weekly updates. Static datasets (uploaded once) have no workflow.
 
 ## Running a Dataset Pipeline
 
@@ -38,7 +38,7 @@ There is no test suite, linter, or build system. Validation happens inside each 
 
 ## Key Files
 
-- `scripts/hf_dataset_utils/` — shared Pipeline library used by all 184 dataset scripts. Provides `Pipeline` context manager that handles temp dirs, parquet writing (zstd), README generation, validation (`check_dataset()`), banner images, and HF upload. Key modules: `pipeline.py`, `validation.py`, `banner.py`, `readme.py`, `upload.py`, `tap.py` (VizieR/HEASARC TAP).
+- `scripts/hf_dataset_utils/` — shared Pipeline library used by all 226 dataset scripts. Provides `Pipeline` context manager that handles temp dirs, parquet writing (zstd), README generation, validation (`check_dataset()`), banner images, and HF upload. Key modules: `pipeline.py`, `validation.py`, `banner.py`, `readme.py`, `upload.py`, `tap.py` (VizieR/HEASARC TAP).
 - `scripts/validate.py` — legacy `check_dataset()` function (now re-exported from `hf_dataset_utils.validation`).
 - `scripts/vizier_tap.py` — legacy VizieR TAP client (now re-exported from `hf_dataset_utils.tap`).
 - `scripts/jpl_api.py` — shared helpers for NASA JPL SSD API (NEO, SBDB, Sentry, NHATS). Converts `{"fields": [...], "data": [[...]]}` format to DataFrame.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # space-datasets — Open Space, Astronomy & Physics Datasets on Hugging Face
 
-Open-source data pipelines that publish **220 space, astronomy, and physics datasets** to [Hugging Face](https://huggingface.co/juliensimon) in Parquet format. Covers satellites, orbital mechanics, asteroids, space weather, solar activity, exoplanets, gravitational waves, pulsars, radio surveys, X-ray catalogs, space probes, particle physics, and more — sourced from NASA, NOAA, ESA, SpaceX, Wikidata, and other public APIs. Updated daily via GitHub Actions.
+Open-source data pipelines that publish **230 space, astronomy, and physics datasets** to [Hugging Face](https://huggingface.co/juliensimon) in Parquet format. Covers satellites, orbital mechanics, asteroids, space weather, solar activity, exoplanets, gravitational waves, pulsars, radio surveys, X-ray catalogs, space probes, particle physics, and more — sourced from NASA, NOAA, ESA, SpaceX, Wikidata, and other public APIs. Updated daily via GitHub Actions.
 
 All datasets are loadable in one line (`load_dataset("juliensimon/...")`), require no API keys, and work with `pandas`, `polars`, or any Parquet-compatible tool.
 

--- a/scripts/add-to-collections.py
+++ b/scripts/add-to-collections.py
@@ -323,7 +323,6 @@ DATASETS = {
         "juliensimon/4xmm-dr14-xray-sources",
         "juliensimon/roma-bzcat-blazars",
         "juliensimon/planck-cold-clumps",
-        "juliensimon/gaia-dr3-spectroscopic-binaries",
         "juliensimon/fermi-3pc-gamma-ray-pulsars",
         "juliensimon/nicer-observations",
         "juliensimon/maxi-xray-sources",

--- a/scripts/update-aurora-forecast.py
+++ b/scripts/update-aurora-forecast.py
@@ -30,10 +30,10 @@ COLUMN_DESCRIPTIONS = {
     "forecast_time": "UTC valid time of the nowcast, roughly 30-40 minutes after the observation time (the lead time for aurora to respond).",
     "north_total_power": "Sum of aurora probability (%) over all Northern-Hemisphere grid cells. A unitless index proportional to total Northern auroral activity; rises sharply during geomagnetic storms.",
     "north_max_intensity": "Peak aurora probability (%) in any Northern-Hemisphere cell (0-100). 100 means visible aurora is essentially certain somewhere in the north.",
-    "north_active_cells": f"Number of Northern-Hemisphere grid cells with aurora probability >= {ACTIVE_THRESHOLD}%, a proxy for the spatial extent (area) of the northern auroral oval.",
+    "north_active_cells": f"Number of Northern-Hemisphere grid cells (0 to ~32,000, up to half the ~65k-cell global grid) with aurora probability >= {ACTIVE_THRESHOLD}%, a proxy for the spatial extent (area) of the northern auroral oval.",
     "south_total_power": "Sum of aurora probability (%) over all Southern-Hemisphere grid cells. Unitless index proportional to total Southern (aurora australis) activity.",
     "south_max_intensity": "Peak aurora probability (%) in any Southern-Hemisphere cell (0-100).",
-    "south_active_cells": f"Number of Southern-Hemisphere grid cells with aurora probability >= {ACTIVE_THRESHOLD}%, a proxy for the area of the southern auroral oval.",
+    "south_active_cells": f"Number of Southern-Hemisphere grid cells (0 to ~32,000, up to half the ~65k-cell global grid) with aurora probability >= {ACTIVE_THRESHOLD}%, a proxy for the area of the southern auroral oval.",
 }
 
 # ── Dataset description ──────────────────────────────────────────────

--- a/scripts/update-goes-xray.py
+++ b/scripts/update-goes-xray.py
@@ -72,19 +72,24 @@ def fetch_xray():
     # Split the two energy bands and join into a wide, one-row-per-minute frame.
     short = (df[df["energy"] == "0.05-0.4nm"][["time_tag", "satellite", "flux"]]
              .rename(columns={"flux": "flux_short"}))
-    long_ = (df[df["energy"] == "0.1-0.8nm"][["time_tag", "flux"]]
+    long_ = (df[df["energy"] == "0.1-0.8nm"][["time_tag", "satellite", "flux"]]
              .rename(columns={"flux": "flux_long"}))
-    wide = short.merge(long_, on="time_tag", how="outer").rename(columns={"time_tag": "datetime"})
+    # Merge on both keys so `satellite` is populated for short-only AND long-only minutes.
+    wide = (short.merge(long_, on=["time_tag", "satellite"], how="outer")
+            .rename(columns={"time_tag": "datetime"}))
 
     for col in ["flux_short", "flux_long"]:
         wide[col] = pd.to_numeric(wide[col], errors="coerce")
     wide["satellite"] = pd.to_numeric(wide["satellite"], errors="coerce").astype("Int64")
 
     # Flare classification from the long-band flux.
+    # right=False -> [low, high) intervals, so flux == 1e-4 classifies as X (>=1e-4),
+    # matching the standard A/B/C/M/X convention and the column description.
     wide["flare_class"] = pd.cut(
         wide["flux_long"],
         bins=[-float("inf"), 1e-7, 1e-6, 1e-5, 1e-4, float("inf")],
         labels=["A", "B", "C", "M", "X"],
+        right=False,
     )
 
     wide = wide.sort_values("datetime").reset_index(drop=True)

--- a/scripts/update-missions-tracker.py
+++ b/scripts/update-missions-tracker.py
@@ -8,6 +8,7 @@ is from the Sun and Earth, where it appears on the sky, and how long its signal
 takes to reach us. Append-by-date: idempotent per UTC day.
 """
 
+import time
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
@@ -91,10 +92,20 @@ def fetch_mission(name, info, day):
         "CSV_FORMAT": "'YES'",
         "ANG_FORMAT": "'DEG'",
     }
+    result = None
+    for attempt in range(3):
+        try:
+            resp = requests.get(HORIZONS_URL, params=params, timeout=45)
+            resp.raise_for_status()
+            result = resp.json().get("result", "")
+            break
+        except requests.RequestException as exc:
+            if attempt == 2:
+                print(f"  WARNING: could not fetch {name} ({info['id']}) after retries: {exc}")
+                return None
+            time.sleep(2 ** attempt)
+
     try:
-        resp = requests.get(HORIZONS_URL, params=params, timeout=45)
-        resp.raise_for_status()
-        result = resp.json().get("result", "")
         block = result.split("$$SOE")[1].split("$$EOE")[0].strip().splitlines()
         # CSV cols: date, solar-flag, lunar-flag, RA, DEC, r, rdot, delta, deldot, LT
         p = [c.strip() for c in block[0].split(",")]
@@ -114,7 +125,7 @@ def fetch_mission(name, info, day):
             "light_time_min": float(p[9]),
         }
     except Exception as exc:
-        print(f"  WARNING: could not fetch {name} ({info['id']}): {exc}")
+        print(f"  WARNING: could not parse Horizons ephemeris for {name} ({info['id']}): {exc}")
         return None
 
 


### PR DESCRIPTION
## Summary

Follow-up to #12 applying the actionable findings from a full quality-review pass over the four new live datasets. No High-severity issues were found; these are correctness, robustness, and consistency fixes.

## Fixes

**Data quality**
- `goes-xray`: merge the short/long XRS bands on `(time_tag, satellite)` instead of `time_tag` alone — previously `satellite` was carried only on the short band, so long-band-only minutes (which drive flare classification) got a null satellite.
- `goes-xray`: classify flares with `pd.cut(..., right=False)` so a flux of exactly `1e-4` is **X**, matching both the standard A/B/C/M/X convention and the column description ("X ≥ 1e-4").

**Robustness**
- `missions-tracker`: wrap each JPL Horizons request in a 3-attempt exponential-backoff retry (parity with the other three pipelines). A transient Horizons hiccup no longer silently drops a mission from that day's snapshot. Network retry and ephemeris-parse errors are now logged distinctly.

**Documentation / consistency**
- `aurora-forecast`: add the `0–~32,000` range to the `*_active_cells` column descriptions.
- `README.md`: fix the intro-prose dataset count (`220 → 230`) so it matches the header.
- `add-to-collections.py`: remove a duplicate `gaia-dr3-spectroscopic-binaries` entry in the Astronomy collection list (pre-existing).
- `CLAUDE.md`: refresh stale counts to `230 datasets / 108 workflows / 226 scripts`.

## Verification

Re-ran the two scripts with logic changes end-to-end against live sources:
- `goes-xray` → merged + validated + published (10,205 rows)
- `missions-tracker` → 9/9 missions, `append_by_date` idempotent (+0 net new), validated + published

All three modified scripts pass `py_compile`.

## Deliberately not included

- `CANDIDATES.md` bookkeeping (marking GOES/conjunctions built): that planning doc has a pre-existing internal count contradiction (line 5 "220" vs line 9 "207") and no strike-through convention — it needs its own reconciliation pass rather than a partial edit here.
- `aurora-forecast` `min_rows=1`: intentional for day-1 seeding; the no-decrease row-trend check still guards against partial-write shrinkage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
